### PR TITLE
Add support for arm64 devices

### DIFF
--- a/config/uber.mk
+++ b/config/uber.mk
@@ -1,100 +1,112 @@
-
-# Written for UBER toolchains
-# Find host os
-
-# Set GCC colors
-export GCC_COLORS := 'error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+# Written for UBER toolchains (UBERTC)
+# Requires a Linux Host
 
 UNAME := $(shell uname -s)
-
 ifeq (Linux,$(UNAME))
   HOST_OS := linux
 endif
 
 ifeq (linux,$(HOST_OS))
 ifeq (arm,$(TARGET_ARCH))
-# Path to toolchain
+# ANDROIDEABI TOOLCHAIN INFO
 AND_TC_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/arm/arm-linux-androideabi-$(TARGET_GCC_VERSION)
 AND_TC_VERSION := $(shell $(AND_TC_PATH)/bin/arm-linux-androideabi-gcc --version 2>&1)
 AND_TC_VERSION_NUMBER := $(shell $(AND_TC_PATH)/bin/arm-linux-androideabi-gcc -dumpversion 2>&1)
-
-# Find strings in version info
+AND_TC_DATE := $(filter 20150% 20151% 20160% 20161%,$(AND_TC_VERSION))
 ifneq ($(filter (UBERTC%),$(AND_TC_VERSION)),)
-AND_TC_NAME := UBERTC
+  AND_TC_NAME := UBERTC
 else
-AND_TC_NAME := GCC
+  AND_TC_NAME := GCC
 endif
-
-AND_TC_DATE := $(filter 20150% 20151% ,$(AND_TC_VERSION))
-ifeq ($(AND_TC_DATE),)
-	AND_TC_DATE := $(filter 2014% ,$(AND_TC_VERSION))
+ifeq (,$(AND_TC_DATE))
+  ARM_AND_PROP := $(AND_TC_NAME)-$(AND_TC_VERSION_NUMBER)
+else
+  ARM_AND_PROP := ($(AND_TC_NAME)-$(AND_TC_VERSION_NUMBER))-$(AND_TC_DATE)
 endif
-
 ADDITIONAL_BUILD_PROPERTIES += \
-    ro.uber.android=($(AND_TC_NAME)-$(AND_TC_VERSION_NUMBER))-$(AND_TC_DATE)
+    ro.uber.android=$(ARM_AND_PROP)
 
+# ARM-EABI TOOLCHAIN INFO
 ifneq ($(TARGET_GCC_VERSION_ARM),)
-KERNEL_TC_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/arm/arm-eabi-$(TARGET_GCC_VERSION_ARM)
+  KERNEL_TC_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/arm/arm-eabi-$(TARGET_GCC_VERSION_ARM)
 else
-KERNEL_TC_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/arm/arm-eabi-$(TARGET_GCC_VERSION)
+  KERNEL_TC_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/arm/arm-eabi-$(TARGET_GCC_VERSION)
 endif
-
 KERNEL_TC_VERSION := $(shell $(KERNEL_TC_PATH)/bin/arm-eabi-gcc --version 2>&1)
 KERNEL_TC_VERSION_NUMBER := $(shell $(KERNEL_TC_PATH)/bin/arm-eabi-gcc -dumpversion 2>&1)
-
-# Find strings in version info
+KERNEL_TC_DATE := $(filter 20150% 20151% 20160% 20161%,$(KERNEL_TC_VERSION))
 ifneq ($(filter (UBERTC%),$(KERNEL_TC_VERSION)),)
-KERNEL_TC_NAME := UBERTC
+  KERNEL_TC_NAME := UBERTC
 else
-KERNEL_TC_NAME := GCC
+  KERNEL_TC_NAME := GCC
 endif
-
-KERNEL_TC_DATE := $(filter 20150% 20151% ,$(KERNEL_TC_VERSION))
-
-ifeq ($(KERNEL_TC_DATE),)
-	KERNEL_TC_DATE := $(filter 2014% ,$(KERNEL_TC_VERSION))
+ifeq (,$(KERNEL_TC_DATE))
+  ARM_KERNEL_PROP := $(KERNEL_TC_NAME)-$(KERNEL_TC_VERSION_NUMBER)
+else
+  ARM_KERNEL_PROP := ($(KERNEL_TC_NAME)-$(KERNEL_TC_VERSION_NUMBER))-$(KERNEL_TC_DATE)
 endif
-
 ADDITIONAL_BUILD_PROPERTIES += \
-    ro.uber.kernel=($(KERNEL_TC_NAME)-$(KERNEL_TC_VERSION_NUMBER))-$(KERNEL_TC_DATE)
-
+    ro.uber.kernel=$(ARM_KERNEL_PROP)
 endif
 
 ifeq (arm64,$(TARGET_ARCH))
-# Path to toolchain
+# AARCH64 ROM TOOLCHAIN INFO
 UBER_AND_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/aarch64/aarch64-linux-android-4.9
 UBER_AND := $(shell $(UBER_AND_PATH)/bin/aarch64-linux-android-gcc --version)
-
-# Find strings in version info
+UBER_AND_VERSION_NUMBER := $(shell $(AND_TC_PATH)/bin/aarch64-linux-android-gcc -dumpversion 2>&1)
+UBER_AND_DATE := $(filter 20150% 20151% 20160% 20161%,$(UBER_AND))
 ifneq ($(filter (UBERTC%),$(UBER_AND)),)
-UBER_AND_NAME := $(filter (UBERTC%),$(UBER_AND))
-UBER_AND_DATE := $(filter 20150% 20151%,$(UBER_AND))
-UBER_AND_VERSION := $(UBER_AND_NAME)-$(UBER_AND_DATE)
+  UBER_AND_NAME := UBERTC
+else
+  UBER_AND_NAME := GCC
+endif
+ifeq (,$(UBER_AND_DATE))
+  AARCH64_AND_PROP := $(UBER_AND_NAME)-$(UBER_AND_VERSION_NUMBER)
+else
+  AARCH64_AND_PROP := ($(UBER_AND_NAME)-$(UBER_AND_VERSION_NUMBER))-$(UBER_AND_DATE)
+endif
 ADDITIONAL_BUILD_PROPERTIES += \
-    ro.uber.android=$(UBER_AND_VERSION)
+    ro.uber.android=$(AARCH64_AND_PROP)
+
+# AARCH64 KERNEL TOOLCHAIN INFO
+ifneq ($(TARGET_GCC_VERSION_ARM64),)
+  UBER_TC_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/aarch64/aarch64-linux-android-$(TARGET_GCC_VERSION_ARM64)
+else
+  UBER_TC_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/aarch64/aarch64-linux-android-4.9
 endif
+UBER_TC_VERSION := $(shell $(UBER_TC_PATH)/bin/aarch64-linux-android-gcc --version)
+UBER_TC_VERSION_NUMBER := $(shell $(UBER_TC_PATH)/bin/aarch64-linux-android-gcc -dumpversion 2>&1)
+UBER_TC_DATE := $(filter 20150% 20151% 20160% 20161%,$(UBER_TC_VERSION))
+ifneq ($(filter (UBERTC%),$(UBER_TC_VERSION)),)
+  UBER_TC_NAME := UBERTC
+else
+  UBER_TC_NAME := GCC
+endif
+ifeq (,$(UBER_TC_DATE))
+  AARCH64_KERNEL_PROP := $(UBER_TC_NAME)-$(UBER_TC_VERSION_NUMBER)
+else
+  AARCH64_KERNEL_PROP := ($(UBER_TC_NAME)-$(UBER_TC_VERSION_NUMBER))-$(UBER_TC_DATE)
+endif
+ADDITIONAL_BUILD_PROPERTIES += \
+    ro.uber.kernel=$(AARCH64_KERNEL_PROP)
 endif
 
+# UBERTC OPTIMIZATIONS 
 ifeq (true,$(STRICT_ALIASING))
-OPT1 := (strict)
+  OPT1 := (strict)
 endif
-
 ifeq (true,$(GRAPHITE_OPTS))
-OPT2 := (graphite)
+  OPT2 := (graphite)
 endif
-
 ifeq (true,$(KRAIT_TUNINGS))
-OPT3 := ($(TARGET_CPU_VARIANT))
+  OPT3 := ($(TARGET_CPU_VARIANT))
 endif
-
 ifeq (true,$(ENABLE_GCCONLY))
-OPT4 := (gcconly)
+  OPT4 := (gcconly)
 endif
-
 ifeq (true,$(CLANG_O3))
-OPT5 := (clang_O3)
+  OPT5 := (clang_O3)
 endif
-
 GCC_OPTIMIZATION_LEVELS := $(OPT1)$(OPT2)$(OPT3)$(OPT4)$(OPT5)
 ifneq (,$(GCC_OPTIMIZATION_LEVELS))
 ADDITIONAL_BUILD_PROPERTIES += \

--- a/config/uber.mk
+++ b/config/uber.mk
@@ -16,7 +16,11 @@ AND_TC_DATE := $(filter 20150% 20151% 20160% 20161%,$(AND_TC_VERSION))
 ifneq ($(filter (UBERTC%),$(AND_TC_VERSION)),)
   AND_TC_NAME := UBERTC
 else
+ifneq ($(filter (Linaro%),$(AND_TC_VERSION)),)
+  AND_TC_NAME := LINARO
+else
   AND_TC_NAME := GCC
+endif
 endif
 ifeq (,$(AND_TC_DATE))
   ARM_AND_PROP := $(AND_TC_NAME)-$(AND_TC_VERSION_NUMBER)
@@ -38,7 +42,11 @@ KERNEL_TC_DATE := $(filter 20150% 20151% 20160% 20161%,$(KERNEL_TC_VERSION))
 ifneq ($(filter (UBERTC%),$(KERNEL_TC_VERSION)),)
   KERNEL_TC_NAME := UBERTC
 else
+ifneq ($(filter (Linaro%),$(KERNEL_TC_VERSION)),)
+  KERNEL_TC_NAME := LINARO
+else
   KERNEL_TC_NAME := GCC
+endif
 endif
 ifeq (,$(KERNEL_TC_DATE))
   ARM_KERNEL_PROP := $(KERNEL_TC_NAME)-$(KERNEL_TC_VERSION_NUMBER)
@@ -51,14 +59,22 @@ endif
 
 ifeq (arm64,$(TARGET_ARCH))
 # AARCH64 ROM TOOLCHAIN INFO
+ifneq ($(TARGET_GCC_VERSION_ARM64_ROM),)
+UBER_AND_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/aarch64/aarch64-linux-android-$(TARGET_GCC_VERSION_ARM64_ROM)
+else
 UBER_AND_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/aarch64/aarch64-linux-android-4.9
+endif
 UBER_AND := $(shell $(UBER_AND_PATH)/bin/aarch64-linux-android-gcc --version)
 UBER_AND_VERSION_NUMBER := $(shell $(UBER_AND_PATH)/bin/aarch64-linux-android-gcc -dumpversion 2>&1)
 UBER_AND_DATE := $(filter 20150% 20151% 20160% 20161%,$(UBER_AND))
 ifneq ($(filter (UBERTC%),$(UBER_AND)),)
   UBER_AND_NAME := UBERTC
+else 
+ifneq ($(filter (Linaro%),$(UBER_AND)),)
+  UBER_AND_NAME := Linaro
 else
   UBER_AND_NAME := GCC
+endif
 endif
 ifeq (,$(UBER_AND_DATE))
   AARCH64_AND_PROP := $(UBER_AND_NAME)-$(UBER_AND_VERSION_NUMBER)
@@ -80,8 +96,13 @@ UBER_TC_DATE := $(filter 20150% 20151% 20160% 20161%,$(UBER_TC_VERSION))
 ifneq ($(filter (UBERTC%),$(UBER_TC_VERSION)),)
   UBER_TC_NAME := UBERTC
 else
+ifneq ($(filter (Linaro%),$(UBER_TC_VERSION)),)
+  UBER_TC_NAME := Linaro
+else
   UBER_TC_NAME := GCC
 endif
+endif
+
 ifeq (,$(UBER_TC_DATE))
   AARCH64_KERNEL_PROP := $(UBER_TC_NAME)-$(UBER_TC_VERSION_NUMBER)
 else

--- a/config/uber.mk
+++ b/config/uber.mk
@@ -53,7 +53,7 @@ ifeq (arm64,$(TARGET_ARCH))
 # AARCH64 ROM TOOLCHAIN INFO
 UBER_AND_PATH := prebuilts/gcc/$(HOST_PREBUILT_TAG)/aarch64/aarch64-linux-android-4.9
 UBER_AND := $(shell $(UBER_AND_PATH)/bin/aarch64-linux-android-gcc --version)
-UBER_AND_VERSION_NUMBER := $(shell $(AND_TC_PATH)/bin/aarch64-linux-android-gcc -dumpversion 2>&1)
+UBER_AND_VERSION_NUMBER := $(shell $(UBER_AND_PATH)/bin/aarch64-linux-android-gcc -dumpversion 2>&1)
 UBER_AND_DATE := $(filter 20150% 20151% 20160% 20161%,$(UBER_AND))
 ifneq ($(filter (UBERTC%),$(UBER_AND)),)
   UBER_AND_NAME := UBERTC


### PR DESCRIPTION
Note: Setting Kernel and ROM version and paths are simplified now! i.e
for ARM : 
TARGET_GCC_VERSION := 4.9 to set ROM TC
TARGET_GCC_VERSION_ARM := 4.9 to set Kernel TC

for ARM64 : 
TARGET_GCC_VERSION_ARM64_ROM := 4.9 to set ROM TC
ARGET_GCC_VERSION_ARM64 := 4.9 to set Kernel TC

no need to set toolchain path i.e
"KERNEL_TOOLCHAIN := $(ANDROID_BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86/arm/arm-eabi-4.9/bin" from now.

uber makefile is smart and auto sets the kernel path!